### PR TITLE
FizzBuzzにおいて数字以外の引数が渡されたときにエラー表示を返す

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -1,4 +1,15 @@
+import math
+
+
 def printFizzBuzzResult(num):
+    if not isinstance(num, (int, float)):
+        print("数字を入力してください")
+        return
+
+    if math.floor(num) != num:
+        print("整数を入力してください")
+        return
+
     if num % 3 == 0 and num % 5 == 0:
         print("FizzBuzz")
     elif num % 3 == 0:
@@ -6,7 +17,12 @@ def printFizzBuzzResult(num):
     elif num % 5 == 0:
         print("Buzz")
     else:
-        print(num)
+        print("FizzでもBuzzでもない")
 
 
+printFizzBuzzResult(3)
 printFizzBuzzResult(5)
+printFizzBuzzResult(15)
+printFizzBuzzResult(1)
+printFizzBuzzResult(0.1)
+printFizzBuzzResult("number")


### PR DESCRIPTION
## 関連 issue

https://github.com/pex-dev/discord-translation-bot/issues/14

## 作業内容

- FizzBuzzの引数によって返答を変えました。
- FizzBuzzの応答に加え以下の変更を加えました。
  - 少数の場合はif math.floorによって処理を行い"整数を入力してください"を出力
  - 文字の場合はif not isinstanceによって処理を行い"数字を入力してください"を出力

## 確認事項

- [ ] セルフコメントの追加

## レビュー・動作確認方法

1.
